### PR TITLE
Failing Timeout Step

### DIFF
--- a/vars/failingTimeout.groovy
+++ b/vars/failingTimeout.groovy
@@ -1,0 +1,25 @@
+/* Copyright (c) 2019 - 2019 TomTom N.V. All rights reserved.
+ *
+ * This software is the proprietary copyright of TomTom N.V. and its subsidiaries and may be
+ * used for internal evaluation purposes or commercial use strictly subject to separate
+ * licensee agreement between you and TomTom. If you are the licensee, you are only permitted
+ * to use this Software in accordance with the terms of your license agreement. If you are
+ * not the licensee then you are not authorised to use this software in any manner and should
+ * immediately return it to TomTom N.V.
+ */
+
+def call(Map conf, Closure body) {
+    try {
+        timeout(conf) {
+            body()
+        }
+    } catch(org.jenkinsci.plugins.workflow.steps.FlowInterruptedException err) {
+        errorCause = err.causes.get(0)
+        // Specially handle the timeout case
+        if(errorCause instanceof org.jenkinsci.plugins.workflow.steps.TimeoutStepExecution.ExceededTimeout) { // SYSTEM means timeout.
+            error "Build failed due to timeout."
+        } else {
+            throw err
+        }
+    }
+}

--- a/vars/failingTimeout.groovy
+++ b/vars/failingTimeout.groovy
@@ -12,18 +12,9 @@
  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
  * See the License for the specific language governing permissions and
  * limitations under the License.
- * /
-
- /*
- * failingTimeout()
- * Description: Wraps a timeout call and throws an error rather than an abort if the timeout is exceeded.
- * Modified from https://support.cloudbees.com/hc/en-us/articles/226554067/comments/360000870712
- * args:
- *  conf: Map is passed directly to the timeout step, see https://jenkins.io/doc/pipeline/steps/workflow-basic-steps/#timeout-enforce-time-limit
- *  body: Closure that is wrapped by timeout
  */
-
 def call(Map conf, Closure body) {
+    // Modified from https://support.cloudbees.com/hc/en-us/articles/226554067/comments/360000870712
     try {
         timeout(conf) {
             body()

--- a/vars/failingTimeout.groovy
+++ b/vars/failingTimeout.groovy
@@ -1,12 +1,20 @@
-/* Copyright (c) 2019 - 2019 TomTom N.V. All rights reserved.
+/*
+ * Copyright (C) 2012-2019, TomTom (http://tomtom.com).
  *
- * This software is the proprietary copyright of TomTom N.V. and its subsidiaries and may be
- * used for internal evaluation purposes or commercial use strictly subject to separate
- * licensee agreement between you and TomTom. If you are the licensee, you are only permitted
- * to use this Software in accordance with the terms of your license agreement. If you are
- * not the licensee then you are not authorised to use this software in any manner and should
- * immediately return it to TomTom N.V.
- * 
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ * /
+
+ /*
  * failingTimeout()
  * Description: Wraps a timeout call and throws an error rather than an abort if the timeout is exceeded.
  * Modified from https://support.cloudbees.com/hc/en-us/articles/226554067/comments/360000870712

--- a/vars/failingTimeout.groovy
+++ b/vars/failingTimeout.groovy
@@ -6,6 +6,13 @@
  * to use this Software in accordance with the terms of your license agreement. If you are
  * not the licensee then you are not authorised to use this software in any manner and should
  * immediately return it to TomTom N.V.
+ * 
+ * failingTimeout()
+ * Description: Wraps a timeout call and throws an error rather than an abort if the timeout is exceeded.
+ * Modified from https://support.cloudbees.com/hc/en-us/articles/226554067/comments/360000870712
+ * args:
+ *  conf: Map is passed directly to the timeout step, see https://jenkins.io/doc/pipeline/steps/workflow-basic-steps/#timeout-enforce-time-limit
+ *  body: Closure that is wrapped by timeout
  */
 
 def call(Map conf, Closure body) {

--- a/vars/failingTimeout.txt
+++ b/vars/failingTimeout.txt
@@ -1,0 +1,29 @@
+# failingTimeout
+
+## Description
+
+Wraps a timeout call and throws an error rather than an abort if the timeout is exceeded.
+See https://jenkins.io/doc/pipeline/steps/workflow-basic-steps/#timeout-enforce-time-limit for details of timeout step.
+
+### Dependencies
+
+## Parameters
+
+### time
+
+int - duration to wait for completion
+
+### activity (optional)
+
+boolean - Timeout after no activity in logs for this block instead of absolute duration. 
+
+### unit (optional)
+
+Values: NANOSECONDS, MICROSECONDS, MILLISECONDS, SECONDS, MINUTES, HOURS, DAYS
+
+## Snippet
+
+```groovy
+@Library(['github.com/tomtom-international/jsl']) _
+failingTimeout time: "10", activity: true, unit: "SECONDS"
+```


### PR DESCRIPTION
Adds a wrapping step called failingTimeout which takes the closure given to it and passes it to a timeout step.
If the timeout is exceeded, the exception is caught, and converted to an error if it is timeout, otherwise the error is rethrown.
This allows a timeout to fail a job rather than abort it.