### PR TITLE
feat: introduce a simple pipeline for gradle based  projects

### DIFF
--- a/vars/gradlePipeline.groovy
+++ b/vars/gradlePipeline.groovy
@@ -1,0 +1,75 @@
+/* Copyright (c) 2019 - 2019 TomTom N.V. All rights reserved.
+ *
+ * This software is the proprietary copyright of TomTom N.V. and its subsidiaries and may be
+ * used for internal evaluation purposes or commercial use strictly subject to separate
+ * licensee agreement between you and TomTom. If you are the licensee, you are only permitted
+ * to use this Software in accordance with the terms of your license agreement. If you are
+ * not the licensee then you are not authorised to use this software in any manner and should
+ * immediately return it to TomTom N.V.
+ */
+
+def call(Map pipelineParams) {
+  def LOG_TAG = "[gradlePipeline]"
+
+  if (!pipelineParams.sshAgentUser) {
+    error ("${LOG_TAG} Please provide pipelineParams.sshAgentUser")
+  }
+
+  pipeline {
+    agent {
+      label "docker"
+    }
+
+    parameters {
+      booleanParam(defaultValue: false, description: 'Release', name: 'doRelease')
+    }
+
+    options {
+      disableConcurrentBuilds()
+    }
+
+    stages {
+      stage("Build & Test") {
+        when {
+          beforeAgent true
+          expression {
+            !params.doRelease
+          }
+        }
+        steps {
+          sh "./gradlew check"
+        }
+        post {
+          always {
+            junit allowEmptyResults: true, testResults: 'build/test-results/**/*.xml'
+          }
+        }
+      }
+
+      stage("Release") {
+        when {
+          beforeAgent true
+          allOf {
+            anyOf {
+              branch "master"
+              branch "release/*"
+            }
+            expression {
+              params.doRelease
+            }
+          }
+        }
+        steps {
+          sshagent([pipelineParams.sshAgentUser]) {
+            sh "./gradlew release"
+          }
+        }
+        post {
+          always {
+            junit allowEmptyResults: true, testResults: 'build/test-results/**/*.xml'
+          }
+        }
+      }
+    }
+  }
+}

--- a/vars/gradlePipeline.txt
+++ b/vars/gradlePipeline.txt
@@ -1,0 +1,20 @@
+# gradlePipeline
+
+## Description
+
+A simple pipeline for Gradle based projects.
+
+### Dependencies
+
+## Parameters
+
+### sshAgentUser
+
+SSH agent user used by the Gradle release plugin during the release (commit of version bump).
+
+## Snippet
+
+```groovy
+@Library(['github.com/tomtom-international/jsl']) _
+gradlePipeline sshAgentUser: "ssh_svc_user"
+```


### PR DESCRIPTION
This is a very simple Gradle pipeline with on-demand releasing enabled.

By default the pipeline will run only the ./gradlew check command on branches (feature and master) and PRs. If a build is triggered on master and the `doRelease` box is ticked it will do `./gradlew release` instead.

I know this is far from being perfect and in fact this pipeline and the gradleDockerPipeline should be merged together.