### PR TITLE
feat: Make build, lint and test commands customizable

### DIFF
--- a/vars/pythonSetupPyPipeline.groovy
+++ b/vars/pythonSetupPyPipeline.groovy
@@ -77,7 +77,7 @@ def call(Map pipelineParams) {
               }
             }
             steps {
-              sh "python setup.py build"
+              sh "${buildCommand}"
             }
           } // Build module
 
@@ -120,7 +120,7 @@ def call(Map pipelineParams) {
                 // setuptools-lint does not do a good job in installing all its dependencies.
                 // use `develop` over `install` to avoid creating an egg file in dist/
                 sh "python setup.py develop --user"
-                sh "python setup.py lint --lint-output-format parseable"
+                sh "${lintCommand}"
               }
             }
             post {
@@ -139,7 +139,7 @@ def call(Map pipelineParams) {
               }
             }
             steps {
-              sh "python setup.py test --addopts '--cov-report xml:build/coverage.xml --cov-report term --cov-branch --junitxml=build/test_results.xml'"
+              sh "${testCommand}"
             }
             post {
               always {
@@ -299,6 +299,9 @@ def initParameterWithBaseValues(Map pipelineParams) {
   pipelineParams["dockerRunArgs"] = pipelineParams.dockerRunArgs ?: ""
   pipelineParams["dockerRunArgs"] += " -v /etc/passwd:/etc/passwd:ro -v /opt/jenkins/.ssh:/opt/jenkins/.ssh:ro --network host"
   pipelineParams["pypiRepo"] = pipelineParams.pypiRepo ?: "https://test.pypi.org/legacy/"
+  pipelineParams["buildCommand"] = pipelineParams.buildCommand ?: "python setup.py build"
+  pipelineParams["lintCommand"] = pipelineParams.lintCommand ?: "python setup.py lint --lint-output-format parseable"
+  pipelineParams["testCommand"] = pipelineParams.testCommand ?: "python setup.py test --addopts '--cov-report xml:build/coverage.xml --cov-report term --cov-branch --junitxml=build/test_results.xml'"
 }
 
 def log(message) {

--- a/vars/pythonSetupPyPipeline.groovy
+++ b/vars/pythonSetupPyPipeline.groovy
@@ -77,7 +77,7 @@ def call(Map pipelineParams) {
               }
             }
             steps {
-              sh "${buildCommand}"
+              sh "${pipelineParams.buildCommand}"
             }
           } // Build module
 
@@ -120,7 +120,7 @@ def call(Map pipelineParams) {
                 // setuptools-lint does not do a good job in installing all its dependencies.
                 // use `develop` over `install` to avoid creating an egg file in dist/
                 sh "python setup.py develop --user"
-                sh "${lintCommand}"
+                sh "${pipelineParams.lintCommand}"
               }
             }
             post {
@@ -139,7 +139,7 @@ def call(Map pipelineParams) {
               }
             }
             steps {
-              sh "${testCommand}"
+              sh "${pipelineParams.testCommand}"
             }
             post {
               always {

--- a/vars/pythonSetupPyPipeline.txt
+++ b/vars/pythonSetupPyPipeline.txt
@@ -36,7 +36,7 @@ Command used to execute linter against the setup.py project [default: `python se
 
 ### testCommand
 
-Command executed in testing stage [deafult: `python setup.py test --addopts '--cov-report xml:build/coverage.xml --cov-report term --cov-branch --junitxml=build/test_results.xml'`].
+Command executed in testing stage [default: `python setup.py test --addopts '--cov-report xml:build/coverage.xml --cov-report term --cov-branch --junitxml=build/test_results.xml'`].
 
 ### dockerFilename
 

--- a/vars/pythonSetupPyPipeline.txt
+++ b/vars/pythonSetupPyPipeline.txt
@@ -26,6 +26,18 @@ Jenkins credentials id used to publish the Python module the specified PyPI repo
 
 SSH agent user used for committing the version bump in release mode (`doRelease` parameter).
 
+### buildCommand
+
+Custom command to execute building setup.py project [default: `python setup.py build`].
+
+### lintCommand
+
+Command used to execute linter against the setup.py project [default: `python setup.py lint --lint-output-format parseable`].
+
+### testCommand
+
+Command executed in testing stage [deafult: `python setup.py test --addopts '--cov-report xml:build/coverage.xml --cov-report term --cov-branch --junitxml=build/test_results.xml'`].
+
 ### dockerFilename
 
 A [multi-stage Dockerfile](https://docs.docker.com/develop/develop-images/multistage-build/) for producing intermediate build/test and deployment images and


### PR DESCRIPTION
These changes aim to make shared library more customizable for projects based on setup.py tool. It allows to execute build, lint and test stages with custom parameters (that would be defined differently for each project). In addition, developers are allowed to utilize intermediate CLI scripts to filter tasks that are specific for a project.