### PR TITLE
feat: Deploy HTML docs to the docs branch of Bitbucket

### DIFF
--- a/vars/pythonSetupPyPipeline.groovy
+++ b/vars/pythonSetupPyPipeline.groovy
@@ -215,6 +215,26 @@ def call(Map pipelineParams) {
                                 pipelineParams.dockerRepo, moduleName, moduleVersion)
             }
           } // Deploy Docker
+
+          // Deploy the html documents to the docs branch, which when using "BitBucket Pages" allows serving the documentation directly
+          stage("Deploy Docs") {
+            when {
+              beforeAgent true
+              allOf {
+                branch "master"
+                expression { params.doRelease }
+              }
+            }
+            steps {
+              sshagent([pipelineParams.sshAgentUser]) {
+                script {
+                  sh "ghp-import -m \"Documentation update to $moduleVersion\" -p -b docs build/sphinx/html"
+                  sh "git tag docs-$moduleVersion docs"
+                  sh "git push origin docs --tags"
+                }
+              }
+            }
+          } // Deploy Docs
         }
       } // Deploy
 

--- a/vars/pythonSetupPyPipeline.groovy
+++ b/vars/pythonSetupPyPipeline.groovy
@@ -226,6 +226,7 @@ def call(Map pipelineParams) {
               }
             }
             when {
+              // beforeAgent is not set to true as docker agent is required to check if ghp-import is installed
               allOf {
                 branch "master"
                 expression {

--- a/vars/pythonSetupPyPipeline.groovy
+++ b/vars/pythonSetupPyPipeline.groovy
@@ -236,8 +236,9 @@ def call(Map pipelineParams) {
               }
             }
             steps {
-              sshagent([pipelineParams.sshAgentUser]) {
+              withGitEnv([scmCredentialsId: pipelineParams.scmCredentialsId]) {
                 script {
+                  sh "git fetch origin docs:docs"
                   sh "ghp-import -m \"Documentation update to $moduleVersion\" -p -b docs build/sphinx/html"
                   sh "git tag docs-$moduleVersion docs"
                   sh "git push origin docs --tags"

--- a/vars/pythonSetupPyPipeline.groovy
+++ b/vars/pythonSetupPyPipeline.groovy
@@ -218,8 +218,14 @@ def call(Map pipelineParams) {
 
           // Deploy the html documents to the docs branch, which when using "BitBucket Pages" allows serving the documentation directly
           stage("Deploy Docs") {
+            agent {
+              docker {
+                image buildImageName
+                args pipelineParams.dockerRunArgs
+                reuseNode true
+              }
+            }
             when {
-              beforeAgent true
               allOf {
                 branch "master"
                 expression {

--- a/vars/pythonSetupPyPipeline.groovy
+++ b/vars/pythonSetupPyPipeline.groovy
@@ -222,7 +222,11 @@ def call(Map pipelineParams) {
               beforeAgent true
               allOf {
                 branch "master"
-                expression { params.doRelease }
+                expression {
+                  params.doRelease &&
+                  //check if "ghp-import" plugin is installed to deploy docs
+                  isDeployDocsPluginInstalled()
+                }
               }
             }
             steps {
@@ -365,5 +369,14 @@ def deployDockerImage(dockerRegistryUrl, dockerRegistryCredentialsId, dockerFile
     } finally {
       sh "docker rmi ${image.imageName()}"
     }
+  }
+}
+
+def isDeployDocsPluginInstalled() {
+  if (sh(script: "pip list | grep -F ghp-import", returnStatus: true) == 0) {
+    return true
+  } else {
+    log("WARNING:No HTML docs will be deployed due to misalignment of your repo with the cookie-cutter python template. Re-run the template against the repo")
+    return false
   }
 }

--- a/vars/pythonSetupPyPipeline.groovy
+++ b/vars/pythonSetupPyPipeline.groovy
@@ -373,10 +373,5 @@ def deployDockerImage(dockerRegistryUrl, dockerRegistryCredentialsId, dockerFile
 }
 
 def isDeployDocsPluginInstalled() {
-  if (sh(script: "pip list | grep -F ghp-import", returnStatus: true) == 0) {
-    return true
-  } else {
-    log("WARNING:No HTML docs will be deployed due to misalignment of your repo with the cookie-cutter python template. Re-run the template against the repo")
-    return false
-  }
+  return sh(script: "pip show ghp-import", returnStatus: true) == 0
 }


### PR DESCRIPTION
Deploy the Sphinx built HTML files to the docs branch of Bitbucket using https://github.com/davisp/ghp-import.
**ghp-import** will remove all the files located in the remote "docs" branch and then push the generated HTML files to the docs branch.
