### PR TITLE
fix: support deploying docs when using ssh checkouts

### DIFF
--- a/vars/pythonSetupPyPipeline.groovy
+++ b/vars/pythonSetupPyPipeline.groovy
@@ -255,9 +255,8 @@ def call(Map pipelineParams) {
                   if (sh(script: "git fetch origin docs:docs", returnStatus: true) != 0) {
                     sh "git checkout --orphan docs"
                   }
-                  sh "ghp-import -m \"Documentation update to $moduleVersion\" -p -b docs build/sphinx/html"
+                  sh "ghp-import -m \"Documentation update to $moduleVersion\" -b docs build/sphinx/html"
                   sh "git tag docs-$moduleVersion docs"
-                  sh "git push origin docs docs-$moduleVersion"
                 }
               }
             }
@@ -298,6 +297,10 @@ def call(Map pipelineParams) {
           script {
             withGitEnv([scmCredentialsId: pipelineParams.scmCredentialsId]) {
               sh("git push origin master --tags")
+
+              if (sh(script: "git tag -l \"docs-$moduleVersion\"", returnStdout: true) != "") {
+                sh(script: "git push origin docs docs-$moduleVersion")
+              }
             }
           }
         }


### PR DESCRIPTION
When using ssh checkouts one hits several issues:

Mounting `/etc/passwd` from host to container causes that any git command relying on ssh will  use the user from `/etc/passwd´ incl. the home directory. This directory does not exist in the container and therefore the git command (eg. `git fetch origin docs:docs`) fails.

I tried to solve this by modifying the `python-setup-py-build` image which is generated in the very first stage by adding a user that can be injected via docker build-args. The idea was to avoid the mounting of `/etc/passwd`. But once the problem of writing to the home dir got solved I got hit by the `host key verifiation` error. 

This kind of stuff is not really easy to solve in Jenkins and therefore I decided to do what we already do: pushing changes with git from host. 


See as well related tickets on Jenkins side: https://issues.jenkins-ci.org/browse/JENKINS-47026